### PR TITLE
Restart audio with keypress

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -1467,7 +1467,7 @@
 		};
 	h.restartSong = function(e) {
 		audio.currentTime = 0;
-	}
+	};
 	h.stop = function(e) {
     e.stopPropagation();
     e.preventDefault();

--- a/js/main.js
+++ b/js/main.js
@@ -158,6 +158,7 @@
 		Mousetrap.bind('v', function() { h.changeSong('n'); });
 		Mousetrap.bind('x', function() { h.changeSong('p'); });
 		Mousetrap.bind('r', function() { h.toggleShuffle(); });
+		Mousetrap.bind('z', function() { h.restartSong(); });
 
 		Mousetrap.bind('1', function() { State.trigger = 'circle'; });
 		Mousetrap.bind('2', function() { State.trigger = 'chop'; });
@@ -1464,6 +1465,9 @@
 		if (!full) $('.icon-expand').removeClass('icon-contract');
 
 		};
+	h.restartSong = function(e) {
+		audio.currentTime = 0;
+	}
 	h.stop = function(e) {
     e.stopPropagation();
     e.preventDefault();


### PR DESCRIPTION
Added 'z' keypress to set audio.currentTime to 0. Useful when using screen-capture software.